### PR TITLE
Fix errors when running bin/magento setup:install on PHP 8.1

### DIFF
--- a/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/Framework/DB/Adapter/Pdo/Mysql.php
@@ -845,7 +845,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         $parts = preg_split(
             '#(;|\'|"|\\\\|//|--|\n|/\*|\*/)#',
             $sql,
-            null,
+            -1,
             PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
         );
 
@@ -1754,10 +1754,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         if ($columnData['DEFAULT'] !== null && $type != Table::TYPE_TEXT) {
             $options['default'] = $this->quote($columnData['DEFAULT']);
         }
-        if (strlen($columnData['SCALE']) > 0) {
+        if ($columnData['SCALE'] !== null && strlen($columnData['SCALE']) > 0) {
             $options['scale'] = $columnData['SCALE'];
         }
-        if (strlen($columnData['PRECISION']) > 0) {
+        if ($columnData['PRECISION'] !== null && strlen($columnData['PRECISION']) > 0) {
             $options['precision'] = $columnData['PRECISION'];
         }
 


### PR DESCRIPTION
In PHP 8.1 passing `null` as the `$limit` argument to the `preg_split` function is deprecated. In PHP 8.1 passing a variable that is null to the `strlen` function is deprecated as well.

This PR may not fix every PHP 8.1 incompatibility, it only fixes the incompatibilities that I encountered when upgrading our site.