### PR TITLE
make mysql adapter class compatible with 2.4.* and remove condition to retry on Lock wait timeout exceeded exception

### DIFF
--- a/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/Framework/DB/Adapter/Pdo/Mysql.php
@@ -272,8 +272,6 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             2006 => ConnectionException::class,
             // SQLSTATE[HY000]: General error: 2013 Lost connection to MySQL server during query
             2013 => ConnectionException::class,
-            // SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded
-            1205 => LockWaitException::class,
             // SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock
             1213 => DeadlockException::class,
             // SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry

--- a/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/Framework/DB/Adapter/Pdo/Mysql.php
@@ -1,13 +1,12 @@
 <?php
 /**
- * 2.3.x Deadlock Retry Module
+ * 2.4.x Deadlock Retry Module
  */
 
  /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Framework\DB\Adapter\Pdo;
 
 use Magento\Framework\App\ObjectManager;
@@ -17,6 +16,7 @@ use Magento\Framework\DB\Adapter\ConnectionException;
 use Magento\Framework\DB\Adapter\DeadlockException;
 use Magento\Framework\DB\Adapter\DuplicateException;
 use Magento\Framework\DB\Adapter\LockWaitException;
+use Magento\Framework\DB\Adapter\TableNotFoundException;
 use Magento\Framework\DB\Ddl\Table;
 use Magento\Framework\DB\ExpressionConverter;
 use Magento\Framework\DB\LoggerInterface;
@@ -24,13 +24,16 @@ use Magento\Framework\DB\Profiler;
 use Magento\Framework\DB\Query\Generator as QueryGenerator;
 use Magento\Framework\DB\Select;
 use Magento\Framework\DB\SelectFactory;
+use Magento\Framework\DB\Sql\Expression;
 use Magento\Framework\DB\Statement\Parameter;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\Setup\SchemaListener;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\StringUtils;
-use Magento\Framework\Setup\SchemaListener;
+use Zend_Db_Adapter_Exception;
+use Zend_Db_Statement_Exception;
 
 // @codingStandardsIgnoreStart
 
@@ -48,35 +51,36 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 {
     // @codingStandardsIgnoreEnd
 
-    const TIMESTAMP_FORMAT      = 'Y-m-d H:i:s';
-    const DATETIME_FORMAT       = 'Y-m-d H:i:s';
-    const DATE_FORMAT           = 'Y-m-d';
+    public const TIMESTAMP_FORMAT      = 'Y-m-d H:i:s';
+    public const DATETIME_FORMAT       = 'Y-m-d H:i:s';
+    public const DATE_FORMAT           = 'Y-m-d';
 
-    const DDL_DESCRIBE          = 1;
-    const DDL_CREATE            = 2;
-    const DDL_INDEX             = 3;
-    const DDL_FOREIGN_KEY       = 4;
-    const DDL_CACHE_PREFIX      = 'DB_PDO_MYSQL_DDL';
-    const DDL_CACHE_TAG         = 'DB_PDO_MYSQL_DDL';
+    public const DDL_DESCRIBE          = 1;
+    public const DDL_CREATE            = 2;
+    public const DDL_INDEX             = 3;
+    public const DDL_FOREIGN_KEY       = 4;
+    private const DDL_EXISTS           = 5;
+    public const DDL_CACHE_PREFIX      = 'DB_PDO_MYSQL_DDL';
+    public const DDL_CACHE_TAG         = 'DB_PDO_MYSQL_DDL';
 
-    const LENGTH_TABLE_NAME     = 64;
-    const LENGTH_INDEX_NAME     = 64;
-    const LENGTH_FOREIGN_NAME   = 64;
+    public const LENGTH_TABLE_NAME     = 64;
+    public const LENGTH_INDEX_NAME     = 64;
+    public const LENGTH_FOREIGN_NAME   = 64;
 
     /**
      * MEMORY engine type for MySQL tables
      */
-    const ENGINE_MEMORY = 'MEMORY';
+    public const ENGINE_MEMORY = 'MEMORY';
 
     /**
      * Maximum number of connection retries
      */
-    const MAX_CONNECTION_RETRIES = 10;
+    public const MAX_CONNECTION_RETRIES = 10;
 
     /**
      * Maximum number of deadlock retries
      */
-    const MAX_DEADLOCK_RETRIES = 5;
+    public const MAX_DEADLOCK_RETRIES = 5;
 
     /**
      * Default class name for a DB statement.
@@ -139,6 +143,13 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @var bool
      */
     protected $_isDdlCacheAllowed = true;
+
+    /**
+     * Save if mysql engine is 8 or not.
+     *
+     * @var bool
+     */
+    private $isMysql8Engine;
 
     /**
      * MySQL column - Table DDL type pairs
@@ -214,7 +225,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     /**
      * Map that links database error code to corresponding Magento exception
      *
-     * @var \Zend_Db_Adapter_Exception[]
+     * @var Zend_Db_Adapter_Exception[]
      */
     private $exceptionMap;
 
@@ -267,10 +278,12 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             1213 => DeadlockException::class,
             // SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
             1062 => DuplicateException::class,
+            // SQLSTATE[42S02]: Base table or view not found: 1146
+            1146 => TableNotFoundException::class,
         ];
         try {
             parent::__construct($config);
-        } catch (\Zend_Db_Adapter_Exception $e) {
+        } catch (Zend_Db_Adapter_Exception $e) {
             throw new \InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }
     }
@@ -381,8 +394,8 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *
      * @return void
-     * @throws \Zend_Db_Adapter_Exception
-     * @throws \Zend_Db_Statement_Exception
+     * @throws Zend_Db_Adapter_Exception
+     * @throws Zend_Db_Statement_Exception
      */
     protected function _connect()
     {
@@ -391,15 +404,15 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         }
 
         if (!extension_loaded('pdo_mysql')) {
-            throw new \Zend_Db_Adapter_Exception('pdo_mysql extension is not installed');
+            throw new Zend_Db_Adapter_Exception('pdo_mysql extension is not installed');
         }
 
         if (!isset($this->_config['host'])) {
-            throw new \Zend_Db_Adapter_Exception('No host configured to connect');
+            throw new Zend_Db_Adapter_Exception('No host configured to connect');
         }
 
         if (isset($this->_config['port'])) {
-            throw new \Zend_Db_Adapter_Exception('Port must be configured within host parameter (like localhost:3306');
+            throw new Zend_Db_Adapter_Exception('Port must be configured within host parameter (like localhost:3306');
         }
 
         unset($this->_config['port']);
@@ -413,6 +426,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 
         if (!isset($this->_config['driver_options'][\PDO::MYSQL_ATTR_MULTI_STATEMENTS])) {
             $this->_config['driver_options'][\PDO::MYSQL_ATTR_MULTI_STATEMENTS] = false;
+        }
+
+        if (!isset($this->_config['driver_options'][\PDO::ATTR_STRINGIFY_FETCHES])) {
+            $this->_config['driver_options'][\PDO::ATTR_STRINGIFY_FETCHES] = true;
         }
 
         $this->logger->startTimer();
@@ -513,12 +530,12 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      *
      * @param string|\Magento\Framework\DB\Select $sql
      * @return void
-     * @throws \Zend_Db_Adapter_Exception
+     * @throws Zend_Db_Adapter_Exception
      */
     protected function _checkDdlTransaction($sql)
     {
         if ($this->getTransactionLevel() > 0) {
-            $sql = ltrim(preg_replace('/\s+/', ' ', $sql));
+            $sql = $sql !== null ? ltrim(preg_replace('/\s+/', ' ', $sql)) : '';
             $sqlMessage = explode(' ', $sql, 3);
             $startSql = strtolower(substr($sqlMessage[0], 0, 3));
             if (in_array($startSql, $this->_ddlRoutines) && strcasecmp($sqlMessage[1], 'temporary') !== 0) {
@@ -535,8 +552,8 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @param string|\Magento\Framework\DB\Select $sql The SQL statement with placeholders.
      * @param mixed $bind An array of data or data itself to bind to the placeholders.
      * @return \Zend_Db_Statement_Pdo|void
-     * @throws \Zend_Db_Adapter_Exception To re-throw \PDOException.
-     * @throws \Zend_Db_Statement_Exception
+     * @throws Zend_Db_Adapter_Exception To re-throw \PDOException.
+     * @throws Zend_Db_Statement_Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     protected function _query($sql, $bind = [])
@@ -555,7 +572,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         ];
 
         /** @var \Psr\Log\LoggerInterface $stringLogger */
-        $stringLogger = ObjectManager::getInstance()->get('Psr\Log\LoggerInterface');
+        $stringLogger = ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class);
 
         // *** Deadlock module edits: End ***
 
@@ -581,7 +598,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                 $pdoException = null;
                 if ($e instanceof \PDOException) {
                     $pdoException = $e;
-                } elseif (($e instanceof \Zend_Db_Statement_Exception)
+                } elseif (($e instanceof Zend_Db_Statement_Exception)
                     && ($e->getPrevious() instanceof \PDOException)
                 ) {
                     $pdoException = $e->getPrevious();
@@ -595,14 +612,6 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                     $triesCount++;
                     $this->closeConnection();
 
-                    /**
-                     * _connect() function does not allow port parameter, so put the port back with the host
-                     */
-                    if (!empty($this->_config['port'])) {
-                        $this->_config['host'] = implode(':', [$this->_config['host'], $this->_config['port']]);
-                        unset($this->_config['port']);
-                    }
-
                     $this->_connect();
 
                 // *** Deadlock module edits: Start ***
@@ -612,11 +621,11 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                     && in_array($pdoException->errorInfo[1], $deadlockErrors)){
                     $retry = true;
                     $triesCount++;
-                    $sleepSeconds = pow($triesCount, 2);
+                    $sleepSeconds = $triesCount ** 2;
                     $stringLogger->critical("Encountered Deadlock Exception. Retrying in {$sleepSeconds} seconds. Full exception details below. " . $e->getMessage() . "\n" . $e->getTraceAsString());
                     sleep($sleepSeconds);
 
-                // *** Deadlock module edits: End ***    
+                // *** Deadlock module edits: End ***
                 }
 
                 if (!$retry) {
@@ -625,7 +634,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                     // rethrow custom exception if needed
                     if ($pdoException && isset($this->exceptionMap[$pdoException->errorInfo[1]])) {
                         $customExceptionClass = $this->exceptionMap[$pdoException->errorInfo[1]];
-                        /** @var \Zend_Db_Adapter_Exception $customException */
+                        /** @var Zend_Db_Adapter_Exception $customException */
                         $customException = new $customExceptionClass($e->getMessage(), $pdoException->errorInfo[1], $e);
                         throw $customException;
                     }
@@ -643,13 +652,16 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @param string|\Magento\Framework\DB\Select $sql The SQL statement with placeholders.
      * @param mixed $bind An array of data or data itself to bind to the placeholders.
      * @return \Zend_Db_Statement_Pdo|void
-     * @throws \Zend_Db_Adapter_Exception To re-throw \PDOException.
+     * @throws Zend_Db_Adapter_Exception To re-throw \PDOException.
      * @throws LocalizedException In case multiple queries are attempted at once, to protect from SQL injection
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function query($sql, $bind = [])
     {
-        if (strpos(rtrim($sql, " \t\n\r\0;"), ';') !== false && count($this->_splitMultiQuery($sql)) > 1) {
+        if ($sql !== null &&
+            strpos(rtrim($sql, " \t\n\r\0;"), ';') !== false &&
+            count($this->_splitMultiQuery($sql)) > 1
+        ) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 new Phrase("Multiple queries can't be executed. Run a single query and try again.")
             );
@@ -668,7 +680,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @param string|\Magento\Framework\DB\Select $sql The SQL statement with placeholders.
      * @param mixed $bind An array of data or data itself to bind to the placeholders.
      * @return \Zend_Db_Statement_Pdo|void
-     * @throws \Zend_Db_Adapter_Exception To re-throw \PDOException.
+     * @throws Zend_Db_Adapter_Exception To re-throw \PDOException.
      * @throws LocalizedException In case multiple queries are attempted at once, to protect from SQL injection
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @deprecated 101.0.0
@@ -684,7 +696,9 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * with named binds.
      *
      * @param \Magento\Framework\DB\Select|string $sql
+     *
      * @param mixed $bind
+     *
      * @return $this
      */
     protected function _prepareQuery(&$sql, &$bind = [])
@@ -695,11 +709,9 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         }
 
         // Mixed bind is not supported - so remember whether it is named bind, to normalize later if required
-        $isNamedBind = false;
         if ($bind) {
             foreach ($bind as $k => $v) {
                 if (!is_int($k)) {
-                    $isNamedBind = true;
                     if ($k[0] != ':') {
                         $bind[":{$k}"] = $v;
                         unset($bind[$k]);
@@ -732,7 +744,8 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         if (isset($matches[6]) && (
             strpos($matches[6], "'") !== false ||
             strpos($matches[6], ':') !== false ||
-            strpos($matches[6], '?') !== false)
+            strpos($matches[6], '?') !== false
+            )
         ) {
             $bindName = ':_mage_bind_var_' . (++$this->_bindIncrement);
             $this->_bindParams[$bindName] = $this->_unQuote($matches[6]);
@@ -773,6 +786,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     {
         $positions  = [];
         $offset     = 0;
+        $sql = (string)$sql;
         // get positions
         while (true) {
             $pos = strpos($sql, '?', $offset);
@@ -845,7 +859,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         $parts = preg_split(
             '#(;|\'|"|\\\\|//|--|\n|/\*|\*/)#',
             $sql,
-            null,
+            -1,
             PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
         );
 
@@ -906,8 +920,9 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     public function dropForeignKey($tableName, $fkName, $schemaName = null)
     {
         $foreignKeys = $this->getForeignKeys($tableName, $schemaName);
-        $fkName = strtoupper($fkName);
+        $fkName = $fkName !== null ? strtoupper($fkName) : '';
         if (substr($fkName, 0, 3) == 'FK_') {
+
             $fkName = substr($fkName, 3);
         }
         foreach ([$fkName, 'FK_' . $fkName] as $key) {
@@ -1094,7 +1109,6 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Retrieve index information by indexed columns or return NULL, if there is no index for a column list
      *
      * @param string $tableName
-     * @param array $columns
      * @param string|null $schemaName
      * @return array|null
      */
@@ -1215,6 +1229,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @param string $tableName
      * @param string $schemaName
      * @return mixed
+     *
+     * @throws LocalizedException
+     * @throws Zend_Db_Adapter_Exception
+     * @throws Zend_Db_Statement_Exception
      */
     public function showTableStatus($tableName, $schemaName = null)
     {
@@ -1223,8 +1241,30 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             $fromDbName = ' FROM ' . $this->quoteIdentifier($schemaName);
         }
         $query = sprintf('SHOW TABLE STATUS%s LIKE %s', $fromDbName, $this->quote($tableName));
+        //checks which slq engine used
+        if (!$this->isMysql8EngineUsed()) {
+            //if it's not MySQl-8 we just fetch results
+            return $this->rawFetchRow($query);
+        }
+        // Run show table status query in different connection because DDL queries do it in transaction,
+        // and we don't have actual table statistic in this case
+        $connection = $this->_transactionLevel ? $this->createConnection() : $this;
+        $connection->query(sprintf('ANALYZE TABLE %s', $this->quoteIdentifier($tableName)));
+        return $connection->query($query)->fetch(\PDO::FETCH_ASSOC);
+    }
 
-        return $this->rawFetchRow($query);
+    /**
+     * Checks if the engine is mysql 8
+     *
+     * @return bool
+     */
+    private function isMysql8EngineUsed(): bool
+    {
+        if (!$this->isMysql8Engine) {
+            $version = $this->fetchPairs("SHOW variables LIKE 'version'")['version'] ?? '';
+            $this->isMysql8Engine = (bool)preg_match('/^(8\.)/', $version);
+        }
+        return $this->isMysql8Engine;
     }
 
     /**
@@ -1515,10 +1555,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Method revrited for handle empty arrays in value param
      *
      * @param string $text The text with a placeholder.
-     * @param mixed $value The value to quote.
-     * @param string $type OPTIONAL SQL datatype
+     * @param array|null|int|string|float|Expression|Select|\DateTimeInterface $value The value to quote.
+     * @param int|string|null $type OPTIONAL SQL datatype of the given value e.g. Zend_Db::FLOAT_TYPE or "INT"
      * @param integer $count OPTIONAL count of placeholders to replace
-     * @return string An SQL-safe quoted value placed into the orignal text.
+     * @return string An SQL-safe quoted value placed into the original text.
      */
     public function quoteInto($text, $value, $type = null, $count = null)
     {
@@ -1634,7 +1674,14 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         } else {
             $cacheKey = $this->_getTableName($tableName, $schemaName);
 
-            $ddlTypes = [self::DDL_DESCRIBE, self::DDL_CREATE, self::DDL_INDEX, self::DDL_FOREIGN_KEY];
+            $ddlTypes = [
+                self::DDL_DESCRIBE,
+                self::DDL_CREATE,
+                self::DDL_INDEX,
+                self::DDL_FOREIGN_KEY,
+                self::DDL_EXISTS
+            ];
+
             foreach ($ddlTypes as $ddlType) {
                 unset($this->_ddlCache[$ddlType][$cacheKey]);
             }
@@ -1744,7 +1791,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             $options['unsigned'] = true;
         }
         if ($columnData['NULLABLE'] === false
-            && !($type == Table::TYPE_TEXT && strlen($columnData['DEFAULT']) != 0)
+            && !($type == Table::TYPE_TEXT && isset($columnData['DEFAULT']) && strlen($columnData['DEFAULT']) != 0)
         ) {
             $options['nullable'] = false;
         }
@@ -1754,10 +1801,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         if ($columnData['DEFAULT'] !== null && $type != Table::TYPE_TEXT) {
             $options['default'] = $this->quote($columnData['DEFAULT']);
         }
-        if (strlen($columnData['SCALE']) > 0) {
+        if (isset($columnData['SCALE']) && strlen($columnData['SCALE']) > 0) {
             $options['scale'] = $columnData['SCALE'];
         }
-        if (strlen($columnData['PRECISION']) > 0) {
+        if (isset($columnData['PRECISION']) && strlen($columnData['PRECISION']) > 0) {
             $options['precision'] = $columnData['PRECISION'];
         }
 
@@ -1867,11 +1914,12 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Retrieve column data type by data from describe table
      *
      * @param array $column
-     * @return string
+     * @return string|null
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     protected function _getColumnTypeByDdl($column)
     {
+        // phpstan:ignore
         switch ($column['DATA_TYPE']) {
             case 'bool':
                 return Table::TYPE_BOOLEAN;
@@ -1906,6 +1954,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             case 'numeric':
                 return Table::TYPE_DECIMAL;
         }
+        return null;
     }
 
     /**
@@ -2002,7 +2051,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                 $field = $this->quoteIdentifier($k);
                 if ($v instanceof \Zend_Db_Expr) {
                     $value = $v->__toString();
-                } elseif ($v instanceof \Zend\Db\Sql\Expression) {
+                } elseif ($v instanceof \Laminas\Db\Sql\Expression) {
                     $value = $v->getExpression();
                 } elseif (is_string($v)) {
                     $value = sprintf('VALUES(%s)', $this->quoteIdentifier($v));
@@ -2360,7 +2409,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     protected function isNdb(Table $table)
     {
-        $engineType = strtolower($table->getOption('type'));
+        $engineType = strtolower($table->getOption('type') ?? '');
         return $engineType == 'ndb' || $engineType == 'ndbcluster';
     }
 
@@ -2659,7 +2708,26 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function isTableExists($tableName, $schemaName = null)
     {
-        return $this->showTableStatus($tableName, $schemaName) !== false;
+        $cacheKey = $this->_getTableName($tableName, $schemaName);
+        $ddl = $this->loadDdlCache($cacheKey, self::DDL_EXISTS);
+        if ($ddl !== false) {
+            return true;
+        }
+        $fromDbName = 'DATABASE()';
+        if ($schemaName !== null) {
+            $fromDbName = $this->quote($schemaName);
+        }
+        $sql = sprintf(
+            'SELECT COUNT(1) AS tbl_exists FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = %s AND TABLE_SCHEMA = %s',
+            $this->quote($tableName),
+            $fromDbName
+        );
+        $ddl = $this->rawFetchRow($sql, 'tbl_exists');
+        if ($ddl) {
+            $this->saveDdlCache($cacheKey, self::DDL_EXISTS, $ddl);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -2752,7 +2820,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         }
         $fieldSql = implode(',', $fieldSql);
 
-        switch (strtolower($indexType)) {
+        switch (strtolower((string)$indexType)) {
             case AdapterInterface::INDEX_TYPE_PRIMARY:
                 $condition = 'PRIMARY KEY';
                 break;
@@ -2775,9 +2843,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                 $result = $this->rawQuery($query);
                 $cycle  = false;
             } catch (\Exception $e) {
-                if (in_array(strtolower($indexType), ['primary', 'unique'])) {
+                if ($indexType !== null && in_array(strtolower($indexType), ['primary', 'unique'])) {
                     $match = [];
-                    if (preg_match('#SQLSTATE\[23000\]: [^:]+: 1062[^\']+\'([\d-\.]+)\'#', $e->getMessage(), $match)) {
+                    //phpstan:ignore
+                    if (preg_match('#SQLSTATE\[23000\]: [^:]+: 1062[^\']+\'([\d.-]+)\'#', $e->getMessage(), $match)) {
                         $ids = explode('-', $match[1]);
                         $this->_removeDuplicateEntry($tableName, $fields, $ids);
                         continue;
@@ -2788,6 +2857,8 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         }
 
         $this->resetDdlCache($tableName, $schemaName);
+
+        // @phpstan-ignore-next-line
 
         return $result;
     }
@@ -2804,7 +2875,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     {
         $indexList = $this->getIndexList($tableName, $schemaName);
         $indexType = 'index';
-        $keyName = strtoupper($keyName);
+        $keyName = $keyName !== null ? strtoupper($keyName) : '';
         if (!isset($indexList[$keyName])) {
             return true;
         }
@@ -3037,12 +3108,13 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Prepare Sql condition
      *
      * @param  string $text Condition value
-     * @param  mixed $value
+     * @param mixed $value
      * @param  string $fieldName
      * @return string
      */
     protected function _prepareQuotedSqlCondition($text, $value, $fieldName)
     {
+        $text = str_replace('{{fieldName}}', (string)$fieldName, (string)$text);
         $sql = $this->quoteInto($text, $value);
         $sql = str_replace('{{fieldName}}', $fieldName, $sql);
         return $sql;
@@ -3447,7 +3519,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             $fields = implode('_', $fields);
         }
 
-        switch (strtolower($indexType)) {
+        switch (strtolower((string)$indexType)) {
             case AdapterInterface::INDEX_TYPE_UNIQUE:
                 $prefix = 'unq_';
                 break;
@@ -3458,6 +3530,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             default:
                 $prefix = 'idx_';
         }
+
         return strtoupper(ExpressionConverter::shortenEntityName($tableName . '_' . $fields, $prefix));
     }
 
@@ -3528,6 +3601,16 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             $query .= ' IGNORE';
         }
         $query = sprintf('%s INTO %s', $query, $this->quoteIdentifier($table));
+
+        $countFieldsInSelect = count($select->getPart(Select::COLUMNS));
+        if (empty($fields) && $countFieldsInSelect > 1) {
+            $fields = array_slice(
+                array_keys($this->describeTable($table)),
+                0,
+                $countFieldsInSelect
+            );
+        }
+
         if ($fields) {
             $columns = array_map([$this, 'quoteIdentifier'], $fields);
             $query = sprintf('%s (%s)', $query, join(', ', $columns));
@@ -3596,6 +3679,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     private function getQueryGenerator()
     {
         if ($this->queryGenerator === null) {
+            // phpcs:ignore Magento2.PHP.AutogeneratedClassNotInConstructor
             $this->queryGenerator = \Magento\Framework\App\ObjectManager::getInstance()->create(QueryGenerator::class);
         }
         return $this->queryGenerator;
@@ -3654,7 +3738,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         // render UPDATE SET
         $columns = [];
         foreach ($select->getPart(\Magento\Framework\DB\Select::COLUMNS) as $columnEntry) {
-            list($correlationName, $column, $alias) = $columnEntry;
+            [$correlationName, $column, $alias] = $columnEntry;
             if (empty($alias)) {
                 $alias = $column;
             }
@@ -4051,7 +4135,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     {
         $indexName = $this->getPrimaryKeyName($tableName, $schemaName);
         $indexes = $this->getIndexList($tableName);
-        if ($indexName && count($indexes[$indexName]['COLUMNS_LIST']) == 1) {
+        if ($indexName && isset($indexes[$indexName]) && count($indexes[$indexName]['COLUMNS_LIST']) == 1) {
             return current($indexes[$indexName]['COLUMNS_LIST']);
         }
         return false;
@@ -4068,8 +4152,26 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     public function getSchemaListener()
     {
         if ($this->schemaListener === null) {
+            // phpcs:ignore Magento2.PHP.AutogeneratedClassNotInConstructor
             $this->schemaListener = \Magento\Framework\App\ObjectManager::getInstance()->create(SchemaListener::class);
         }
         return $this->schemaListener;
+    }
+
+    /**
+     * Closes the connection.
+     *
+     * @since 102.0.4
+     */
+    public function closeConnection()
+    {
+        /**
+         * _connect() function does not allow port parameter, so put the port back with the host
+         */
+        if (!empty($this->_config['port'])) {
+            $this->_config['host'] = implode(':', [$this->_config['host'], $this->_config['port']]);
+            unset($this->_config['port']);
+        }
+        parent::closeConnection();
     }
 }


### PR DESCRIPTION
This PR covers 2 changes:

1. Make mysql adapter class compatible with 2.4.*. Updated for Magento version 2.4.5-p5.
2. Remove Condition retry on Lock wait timeout exceeded as recommended by mysql. 